### PR TITLE
Autodeploy dependabot patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+registries:
+  npm-pipedrive:
+    type: npm-registry
+    url: https://npm-registry-proxy.pipedrive.tools
+    token: ${{ secrets.NPM_TOKEN }}
+  git-pipedrive:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.GHA_ACCESS_TOKEN}}
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:45"
+      timezone: "Europe/Tallinn"
+    rebase-strategy: "disabled"
+    registries:
+      - npm-pipedrive
+      - git-pipedrive

--- a/.github/workflows/dependabot-deploy.yml
+++ b/.github/workflows/dependabot-deploy.yml
@@ -1,0 +1,21 @@
+on:
+  check_suite:
+    type: [completed]
+
+jobs:
+  dependabot-auto-deploy:
+    runs-on: eks-runner
+    timeout-minutes: 1
+    name: Dependabot auto deploy dependencies
+    if: startsWith(github.event.check_suite.head_branch, 'dependabot')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Deploy
+        uses: pipedrive/gha-setup/actions/deploy-dependabot@master
+        with:
+          timezone: Europe/Tallinn
+          target: patch
+          updateIndirectDependencies: true
+          deployOnlyInWorkingHours: true
+          github-token: ${{ secrets.GHA_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

- Setup dependabot to create PRs at a set time inside working hours.
- Setup GHA for dependabot autodeploy of patch versions bumps.
